### PR TITLE
feat: persist Zustand form state to Supabase for page refresh recovery

### DIFF
--- a/netlify/functions/zoho-crm.ts
+++ b/netlify/functions/zoho-crm.ts
@@ -335,7 +335,6 @@ export const handler: Handler = async (event) => {
     if (step === 1) {
       // CREATE lead
       const payload = buildZohoPayload(formData, final);
-      console.log("Zoho create payload:", JSON.stringify(payload, null, 2));
 
       const res = await fetch(baseUrl, {
         method: "POST",
@@ -388,7 +387,6 @@ export const handler: Handler = async (event) => {
       // UPDATE lead
       const payload = buildZohoPayload(formData, final);
       payload.id = zohoLeadId;
-      console.log("Zoho update payload:", JSON.stringify(payload, null, 2));
 
       const res = await fetch(`${baseUrl}/${zohoLeadId}`, {
         method: "PUT",

--- a/src/components/forms/FormContainer.tsx
+++ b/src/components/forms/FormContainer.tsx
@@ -38,6 +38,7 @@ export default function FormContainer() {
     formData, // This is a snapshot, use () for latest
     isSubmitting,
     isSubmitted,
+    isHydrated,
     startTime,
     sessionId,
     triggeredEvents, // This is a snapshot, use () for latest
@@ -49,6 +50,7 @@ export default function FormContainer() {
     addTriggeredEvents,
     getLatestFormData, // Import the new getter
     setZohoLeadId,
+    hydrateFromSupabase,
     bookingFailureContext
   } = useFormStore();
 
@@ -61,8 +63,15 @@ export default function FormContainer() {
   const [showEvaluationAnimation, setShowEvaluationAnimation] = useState(false);
   const [evaluatedLeadCategory, setEvaluatedLeadCategory] = useState<string | null>(null);
   
-  // Track form start when component mounts
+  // Hydrate form state from Supabase on mount (survives page refresh)
   useEffect(() => {
+    hydrateFromSupabase();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Track form start when component mounts (skip if recovering a session)
+  useEffect(() => {
+    if (!isHydrated) return; // Wait for hydration to complete
     const trackFormStart = async () => {
       try {
         // Use getLatestFormData to ensure we have the most current state for initial save

--- a/src/store/formStore.ts
+++ b/src/store/formStore.ts
@@ -12,7 +12,110 @@
 import { create } from 'zustand';
 import { CompleteFormData, UtmParameters, BookingFailureContext } from '@/types/form';
 import { validateFormStep } from '@/lib/form';
-import { generateSessionId } from '@/lib/formTracking';
+import { generateSessionId, getSessionData } from '@/lib/formTracking';
+import { debugLog, errorLog } from '@/lib/logger';
+
+const SESSION_STORAGE_KEY = 'bch_form_session_id';
+
+/** Save sessionId to localStorage so it survives page refresh */
+function persistSessionId(sessionId: string): void {
+  try {
+    localStorage.setItem(SESSION_STORAGE_KEY, sessionId);
+  } catch {
+    // localStorage unavailable (private browsing, etc.) — non-critical
+  }
+}
+
+/** Retrieve persisted sessionId from localStorage */
+function getPersistedSessionId(): string | null {
+  try {
+    return localStorage.getItem(SESSION_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+/** Clear persisted sessionId */
+function clearPersistedSessionId(): void {
+  try {
+    localStorage.removeItem(SESSION_STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Hydrate the store from Supabase if a previous session exists.
+ * Returns hydrated state or null if no recoverable session.
+ */
+async function recoverSession(sessionId: string): Promise<Partial<FormState> | null> {
+  try {
+    const data = await getSessionData(sessionId);
+    if (!data) return null;
+
+    // Don't recover completed or submitted sessions
+    if (data.funnel_stage === '10_form_submit' || data.is_final_submission) {
+      debugLog('Session already submitted, skipping recovery:', sessionId);
+      clearPersistedSessionId();
+      return null;
+    }
+
+    // Don't recover sessions older than 24 hours
+    const createdAt = new Date(data.created_at).getTime();
+    const ageMs = Date.now() - createdAt;
+    if (ageMs > 24 * 60 * 60 * 1000) {
+      debugLog('Session too old, skipping recovery:', sessionId);
+      clearPersistedSessionId();
+      return null;
+    }
+
+    debugLog('Recovering session from Supabase:', sessionId, 'stage:', data.funnel_stage);
+
+    // Map snake_case DB columns back to camelCase form fields
+    const formData: Partial<CompleteFormData> = {};
+    if (data.form_filler_type) formData.formFillerType = data.form_filler_type;
+    if (data.student_name) formData.studentName = data.student_name;
+    if (data.current_grade) formData.currentGrade = data.current_grade;
+    if (data.location) formData.location = data.location;
+    if (data.phone_number) formData.phoneNumber = data.phone_number;
+    if (data.country_code) formData.countryCode = data.country_code;
+    if (data.curriculum_type) formData.curriculumType = data.curriculum_type;
+    if (data.grade_format) formData.gradeFormat = data.grade_format;
+    if (data.gpa_value) formData.gpaValue = data.gpa_value;
+    if (data.percentage_value) formData.percentageValue = data.percentage_value;
+    if (data.school_name) formData.schoolName = data.school_name;
+    if (data.scholarship_requirement) formData.scholarshipRequirement = data.scholarship_requirement;
+    if (data.target_geographies) formData.targetGeographies = data.target_geographies;
+    if (data.parent_name) formData.parentName = data.parent_name;
+    if (data.parent_email) formData.email = data.parent_email;
+    if (data.selected_date) formData.selectedDate = data.selected_date;
+    if (data.selected_slot) formData.selectedSlot = data.selected_slot;
+    if (data.lead_category) formData.lead_category = data.lead_category;
+
+    // Determine step from page_completed
+    const currentStep = data.page_completed >= 2 ? 2 : 1;
+
+    // Recover UTM params
+    const utmParameters: UtmParameters = {};
+    if (data.utm_source) utmParameters.utm_source = data.utm_source;
+    if (data.utm_medium) utmParameters.utm_medium = data.utm_medium;
+    if (data.utm_campaign) utmParameters.utm_campaign = data.utm_campaign;
+    if (data.utm_term) utmParameters.utm_term = data.utm_term;
+    if (data.utm_content) utmParameters.utm_content = data.utm_content;
+    if (data.utm_id) utmParameters.utm_id = data.utm_id;
+
+    return {
+      formData,
+      currentStep,
+      sessionId,
+      utmParameters,
+      startTime: createdAt,
+    };
+  } catch (error) {
+    errorLog('Session recovery failed:', error);
+    return null;
+  }
+}
 
 
 interface FormState {
@@ -20,6 +123,7 @@ interface FormState {
   formData: Partial<CompleteFormData>;
   isSubmitting: boolean;
   isSubmitted: boolean;
+  isHydrated: boolean;
   startTime: number;
   sessionId: string;
   triggeredEvents: string[];
@@ -36,19 +140,27 @@ interface FormState {
   setUtmParameters: (utm: UtmParameters) => void;
   setBookingFailureContext: (ctx: BookingFailureContext) => void;
   setZohoLeadId: (id: string | null) => void;
+  hydrateFromSupabase: () => Promise<void>;
   resetForm: () => void;
   canProceed: (step: number) => boolean;
   getLatestFormData: () => { formData: Partial<CompleteFormData>; triggeredEvents: string[]; utmParameters: UtmParameters };
   incrementEventCounter: () => number;
 }
 
-export const useFormStore = create<FormState>((set, get) => ({
+export const useFormStore = create<FormState>((set, get) => {
+  // Check for persisted session on initialization
+  const persistedId = getPersistedSessionId();
+  const initialSessionId = persistedId || generateSessionId();
+  if (!persistedId) persistSessionId(initialSessionId);
+
+  return {
   currentStep: 1,
   formData: {},
   isSubmitting: false,
   isSubmitted: false,
+  isHydrated: false,
   startTime: Date.now(),
-  sessionId: generateSessionId(),
+  sessionId: initialSessionId,
   triggeredEvents: [],
   utmParameters: {},
   eventCounter: 0,
@@ -86,21 +198,45 @@ export const useFormStore = create<FormState>((set, get) => ({
   })),
   
   setBookingFailureContext: (ctx) => set({ bookingFailureContext: ctx }),
-  setZohoLeadId: (id) => set({ zohoLeadId: id }),
+  setZohoLeadId: (id) => {
+    set({ zohoLeadId: id });
+    if (id) persistSessionId(get().sessionId);
+  },
   
-  resetForm: () => set({
-    currentStep: 1,
-    formData: {},
-    isSubmitting: false,
-    isSubmitted: false,
-    startTime: Date.now(),
-    sessionId: generateSessionId(),
-    triggeredEvents: [],
-    utmParameters: {},
-    eventCounter: 0,
-    bookingFailureContext: { failureType: null, failureReason: null, lastAttemptedDate: null, lastAttemptedSlot: null },
-    zohoLeadId: null
-  }),
+  hydrateFromSupabase: async () => {
+    if (get().isHydrated) return; // Only hydrate once
+    const sessionId = get().sessionId;
+    const recovered = await recoverSession(sessionId);
+    if (recovered) {
+      set({
+        ...recovered,
+        isHydrated: true,
+      });
+      debugLog('Store hydrated from Supabase:', { sessionId, step: recovered.currentStep });
+    } else {
+      set({ isHydrated: true });
+    }
+  },
+  
+  resetForm: () => {
+    clearPersistedSessionId();
+    const newSessionId = generateSessionId();
+    persistSessionId(newSessionId);
+    set({
+      currentStep: 1,
+      formData: {},
+      isSubmitting: false,
+      isSubmitted: false,
+      isHydrated: true,
+      startTime: Date.now(),
+      sessionId: newSessionId,
+      triggeredEvents: [],
+      utmParameters: {},
+      eventCounter: 0,
+      bookingFailureContext: { failureType: null, failureReason: null, lastAttemptedDate: null, lastAttemptedSlot: null },
+      zohoLeadId: null
+    });
+  },
   
   incrementEventCounter: () => {
     const current = get().eventCounter;
@@ -115,4 +251,5 @@ export const useFormStore = create<FormState>((set, get) => ({
       return false;
     }
   }
-}));
+};
+});


### PR DESCRIPTION
- Save sessionId to localStorage on store init and changes
- Add hydrateFromSupabase() action: reads session from Supabase, maps snake_case DB columns back to camelCase form fields, recovers step
- Skip recovery for completed/stale (>24h) sessions
- Call hydrateFromSupabase on FormContainer mount before tracking
- Add isHydrated flag to prevent double hydration
- Remove debug payload logging from zoho-crm.ts