### PR TITLE
fix(ui): add loading state to sticky Continue button on Page 1 (TLS-173)

### DIFF
--- a/src/components/forms/InitialLeadCaptureForm.tsx
+++ b/src/components/forms/InitialLeadCaptureForm.tsx
@@ -731,14 +731,28 @@ export const InitialLeadCaptureForm = forwardRef<InitialLeadCaptureFormRef, Init
           <div className="max-w-4xl mx-auto">
             <button
               onClick={handleStickySubmit}
-              disabled={false}
+              disabled={isSubmitting}
               className={cn(
                 "w-full py-4 rounded-lg text-base md:text-lg font-bold transition-all duration-300 shadow-md flex items-center justify-center space-x-2",
-                "bg-accent text-primary hover:bg-accent-light hover:shadow-lg"
+                isSubmitting
+                  ? "bg-accent/70 text-primary/70 cursor-not-allowed"
+                  : "bg-accent text-primary hover:bg-accent-light hover:shadow-lg"
               )}
             >
-              <span>Continue</span>
-              <ChevronRight className="w-5 h-5" />
+              {isSubmitting ? (
+                <>
+                  <svg className="animate-spin h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                  </svg>
+                  <span>Processing...</span>
+                </>
+              ) : (
+                <>
+                  <span>Continue</span>
+                  <ChevronRight className="w-5 h-5" />
+                </>
+              )}
             </button>
             
             {/* Progress hint */}


### PR DESCRIPTION
Wire existing isSubmitting state to the sticky button so users get instant visual feedback on click. Button now disables, shows a spinner with 'Processing...' text, and reduces opacity during submission.